### PR TITLE
Improves documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ defined in [http://www.w3.org/TR/cors](http://www.w3.org/TR/cors)) in a
 [scotty](http://hackage.haskell.org/package/scotty) application.
 
 ```.haskell
-{-# LANGUAGE UnicodeSyntax #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Main
@@ -58,10 +57,10 @@ module Main
 import Network.Wai.Middleware.Cors
 import Web.Scotty
 
-main ∷ IO ()
+main :: IO ()
 main = scotty 8080 $ do
     middleware simpleCors
-    matchAny  "/" $ text "Success"
+    matchAny "/" $ text "Success"
 ```
 
 The result of following curl command will include the HTTP response


### PR DESCRIPTION
Documents some undocumented functions, adds some tips, and improves links by linking to specific sections of the RFC.

I also removed the -XUnicodeSyntax extension from the README. I thought it was a bit much since it was only used for a single character, but I can add it back if you like.