### PR TITLE
Modify methods used in simpleCorsResourcePolicy

### DIFF
--- a/src/Network/Wai/Middleware/Cors.hs
+++ b/src/Network/Wai/Middleware/Cors.hs
@@ -251,14 +251,15 @@ data CorsResourcePolicy = CorsResourcePolicy
 simpleCorsResourcePolicy ∷ CorsResourcePolicy
 simpleCorsResourcePolicy = CorsResourcePolicy
     { corsOrigins = Nothing
-    , corsMethods = simpleMethods
+    , corsMethods = simpleCorsMethods
     , corsRequestHeaders = []
     , corsExposedHeaders = Nothing
     , corsMaxAge = Nothing
     , corsVaryOrigin = False
     , corsRequireOrigin = False
     , corsIgnoreFailures = False
-    }
+    } where
+  simpleCorsMethods = ["HEAD", "GET", "PUT", "POST", "DELETE", "OPTIONS"]
 
 -- | A Cross-Origin resource sharing (CORS) middleware.
 --


### PR DESCRIPTION
I find it that most people build APIs when using wai-cors hence modifying the request to add the other methods essential.