### PR TITLE
give `simpleHeaders` to `simpleCorsResourcePolicy`

### DIFF
--- a/src/Network/Wai/Middleware/Cors.hs
+++ b/src/Network/Wai/Middleware/Cors.hs
@@ -225,7 +225,7 @@ simpleCorsResourcePolicy ∷ CorsResourcePolicy
 simpleCorsResourcePolicy = CorsResourcePolicy
     { corsOrigins = Nothing
     , corsMethods = simpleMethods
-    , corsRequestHeaders = []
+    , corsRequestHeaders = simpleHeaders
     , corsExposedHeaders = Nothing
     , corsMaxAge = Nothing
     , corsVaryOrigin = False


### PR DESCRIPTION
It makes more sense to give `simpleHeaders` explicitely to the `simpleCorsResourcePolicy`, and by extension to `simpleCors`.

The reason for this is that the preflight request chrome and firefox make vie OPTIONS includes `content-type`, resulting in a 400. As the documentation states, all `simpleHeaders` _except_ `content-type` are implicit when passing the empty list to `corsRequestHeaders`.

I hope this is ok, let me know if I misunderstood the intention regarding `simpleCors`.